### PR TITLE
Update render-site.yml

### DIFF
--- a/.github/workflows/render-site.yml
+++ b/.github/workflows/render-site.yml
@@ -139,10 +139,12 @@ jobs:
         
       # Render pdfs
       - name: Render pdfs of lectures
-        uses: fifsky/html-to-pdf-action@master
+      - name: Convert HTML to PDF
+  uses: markwilson/html2pdf@v1.1
+        uses: markwilson/html2pdf@v1.0
         with:
-          htmlFile: modules/${{ matrix.modulenames }}/${{ matrix.modulenames }}.html
-          outputFile: modules/${{ matrix.modulenames }}/${{ matrix.modulenames }}.pdf
+          htmlPath: modules/${{ matrix.modulenames }}/${{ matrix.modulenames }}.html
+          pdfName: modules/${{ matrix.modulenames }}/${{ matrix.modulenames }}.pdf
           
       # Commit the rendered site files - html files and site_libs files
       - name: Commit pdfs


### PR DESCRIPTION
changing html to pdf action to a different one: 
https://github.com/marketplace/actions/convert-html-to-pdf

since the current one seems to not be working (also for them): https://github.com/fifsky/html-to-pdf-action/actions/runs/3579748210/jobs/6021240703

I think they just need to update things: 
https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md

But figured it would be worth trying a different action