### PR TITLE
Change github action used

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -298,7 +298,7 @@ jobs:
         
       # Render pdfs of slides
       - name: Convert HTML to PDF
-        uses: LukaszLapaj/html-to-pdf-action@master
+        uses: fifsky/html-to-pdf-action@master
         with:
           htmlFile: ./modules/${{ matrix.modulenames }}/${{ matrix.modulenames }}.html
           outputFile: ./modules/${{ matrix.modulenames }}/${{ matrix.modulenames }}.pdf

--- a/.github/workflows/render-site.yml
+++ b/.github/workflows/render-site.yml
@@ -175,7 +175,7 @@ jobs:
         
       # Render pdfs of slides
       - name: Convert HTML to PDF
-        uses: LukaszLapaj/html-to-pdf-action@master
+        uses: fifsky/html-to-pdf-action@master
         with:
           htmlFile: ./modules/${{ matrix.modulenames }}/${{ matrix.modulenames }}.html
           outputFile: ./modules/${{ matrix.modulenames }}/${{ matrix.modulenames }}.pdf


### PR DESCRIPTION
PDFs are rendering unreliably. Changing the github action to one that is more regularly maintained for stability.

LukaszLapaj/html-to-pdf-action@master --> fifsky/html-to-pdf-action@master

The former was forked from the latter. Latter was updated 4 months ago, vs 2 years for the former.

Related to #552..
Related to #541 