### PR TITLE
Update Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -71,6 +71,7 @@ RUN apt-get install -y texlive-fonts-recommended texlive-latex-recommended
 
 # Copy over git token
 COPY git_token.txt .
-  
+RUN rm git_token.txt
+
 # Set final workdir for commands
 WORKDIR /home/rstudio

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -69,9 +69,5 @@ RUN Rscript -e  "install.packages('epitools')"
 RUN apt-get install -y texlive-latex-base texlive-latex-extra
 RUN apt-get install -y texlive-fonts-recommended texlive-latex-recommended
 
-# Copy over git token
-COPY git_token.txt .
-RUN rm git_token.txt
-
 # Set final workdir for commands
 WORKDIR /home/rstudio


### PR DESCRIPTION
This is the dumb fix. 

Since this doesn't use install_github.R it doesn't need the token and it also wasn't having the token deleted. 

I'll be incorporating some better changes and extra layers of security for this monday. But for now since all GH_PATs have been deleted this should be fine. 