### PR TITLE
Bump Docker Image 1.2.0 -> 1.2.1

### DIFF
--- a/config_automation.yml
+++ b/config_automation.yml
@@ -27,4 +27,4 @@ url-check-periodically: true
 make-labs: yes
 
 # What docker image should be used for rendering?
-rendering-docker-image: 'jhudsl/intro_to_r:1.2.0'
+rendering-docker-image: 'jhudsl/intro_to_r:1.2.1'


### PR DESCRIPTION
Updating the docker - totally up to you all :) 

-----

OLD:
```
tbd
```

NEW:
```
attached base packages:
[1] stats     graphics  grDevices utils     datasets  methods   base     

other attached packages:
 [1] lubridate_1.9.4 forcats_1.0.0   stringr_1.5.1   dplyr_1.1.4    
 [5] purrr_1.0.4     readr_2.1.5     tidyr_1.3.1     tibble_3.2.1   
 [9] ggplot2_3.5.2   tidyverse_2.0.0

loaded via a namespace (and not attached):
 [1] vctrs_0.6.5        cli_3.6.5          rlang_1.1.6        stringi_1.8.7     
 [5] generics_0.1.3     glue_1.8.0         hms_1.1.3          scales_1.4.0      
 [9] grid_4.5.0         tzdb_0.5.0         lifecycle_1.0.4    compiler_4.5.0    
[13] RColorBrewer_1.1-3 timechange_0.3.0   pkgconfig_2.0.3    farver_2.1.2      
[17] R6_2.6.1           tidyselect_1.2.1   pillar_1.10.2      magrittr_2.0.3    
[21] tools_4.5.0        withr_3.0.2        gtable_0.3.6   
```